### PR TITLE
Remove thread detection loop + use file enumeration to find Discord's executable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Disables threads responsible for calling GetRawInputData for Discord, Discord PT
 ## Usage
 
 1. Download the latest [Release](https://github.com/PrincessAkira/Discord-Fixer/releases).
-2. Locate the directory in which `Discord.exe`, `DiscordPTB.exe` and `DiscordCanary.exe` is located and place the downloaded executable in it.
+2. Locate where Discord Stable/PTB/Canary is installed and place this executable.
 3. Launch the downloaded executable, this will also launch the relevant executable for Discord.
 
 ### How does it work?

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Disables threads responsible for calling GetRawInputData for Discord, Discord PT
 ### How does it work?
 1. The program attempts to locate a valid `Discord.exe`, `DiscordPTB.exe` and `DiscordCanary.exe` file.
 2. Once the correct file was located, the located file will be launched.
-3. The program will be iterate through the process list until it finds any threads that use the following module: `discord_utils.node`.
-4. Once found, the relevant threads will be suspended.
+3. Using [WinEvent](https://learn.microsoft.com/en-us/windows/win32/winauto/what-are-winevents) [Hooks](https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-setwineventhook), the process waits until a window with the class name of `raw_input` is created.
+4. The process that is hosting the `raw_input` window will have its threads iterated and if any thread is using `discord_utils.node`, it will be suspended.
 
 # Building
 1. Install the latest version of [`GCC`](https://winlibs.com/) and [`UPX`](https://upx.github.io/) for optional compression.

--- a/WinMain.c
+++ b/WinMain.c
@@ -1,25 +1,84 @@
-#include <windows.h>
-#include <pathcch.h>
+#include <Windows.h>
+#include <shlwapi.h>
 #include <tlhelp32.h>
 #include <winternl.h>
 #include <wtsapi32.h>
-#include <shlwapi.h>
-#define printf __builtin_printf
+
+static LPWSTR szFileName = NULL;
+
+void WinEventProc(HWINEVENTHOOK hWinEventHook,
+                  DWORD event,
+                  HWND hwnd,
+                  LONG idObject,
+                  LONG idChild,
+                  DWORD idEventThread,
+                  DWORD dwmsEventTime)
+{
+    WCHAR lpExeName[MAX_PATH] = {};
+    DWORD dwProcessId = 0;
+    DWORD dwThreadId = GetWindowThreadProcessId(hwnd, &dwProcessId);
+    WCHAR ptszClassName[256] = {};
+    HANDLE hThreadSnapshot = NULL;
+    THREADENTRY32 te = {.dwSize = sizeof(THREADENTRY32)};
+
+    RealGetWindowClassW(hwnd, ptszClassName, 256);
+    HANDLE hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, dwProcessId);
+    QueryFullProcessImageNameW(hProcess, 0, lpExeName, &((DWORD){MAX_PATH}));
+    PathStripPathW(_wcslwr(lpExeName));
+    CloseHandle(hProcess);
+
+    if (!wcscmp(lpExeName, szFileName) && !wcscmp(ptszClassName, L"raw_input"))
+    {
+        if (Thread32First((hThreadSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0)), &te))
+        {
+            do
+            {
+                if (te.th32OwnerProcessID != dwProcessId)
+                    continue;
+                DWORD64 ThreadInformation = 0;
+                MODULEENTRY32W me = {.dwSize = sizeof(MODULEENTRY32W)};
+                HANDLE hThread = OpenThread(THREAD_ALL_ACCESS, FALSE, te.th32ThreadID),
+                       hModuleSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE32 | TH32CS_SNAPMODULE, dwProcessId);
+                NtQueryInformationThread(hThread, ThreadQuerySetWin32StartAddress, &ThreadInformation, sizeof(DWORD64), NULL);
+                if (Module32FirstW((hModuleSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE32 | TH32CS_SNAPMODULE, dwProcessId)), &me))
+                    do
+                    {
+                        if (ThreadInformation >= (DWORD64)me.modBaseAddr &&
+                            ThreadInformation <= ((DWORD64)me.modBaseAddr + me.modBaseSize) &&
+                            !wcscmp(me.szModule, L"discord_utils.node"))
+                            SuspendThread(hThread);
+                    } while (Module32NextW(hModuleSnapshot, &me));
+                CloseHandle(hModuleSnapshot);
+                CloseHandle(hThread);
+            } while (Thread32Next(hThreadSnapshot, &te));
+        }
+        CloseHandle(hThreadSnapshot);
+        PostQuitMessage(0);
+    }
+}
+
+BOOL EnumWindowsProc(HWND hWnd, LPARAM lParam)
+{
+    DWORD dwProcessId = 0;
+    WCHAR lpExeName[MAX_PATH] = {};
+    GetWindowThreadProcessId(hWnd, &dwProcessId);
+    HANDLE hProcess = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, dwProcessId);
+    QueryFullProcessImageNameW(hProcess, 0, lpExeName, &((DWORD){MAX_PATH}));
+    PathStripPathW(_wcslwr(lpExeName));
+    CloseHandle(hProcess);
+    if (!wcscmp(lpExeName, szFileName))
+        EndTask(hWnd, FALSE, TRUE);
+    return TRUE;
+}
 
 INT WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nCmdShow)
 {
     CONST LPWSTR lpProcesses[] = {L"discord.exe", L"discordptb.exe", L"discordptb.exe"};
     WCHAR lpPathName[MAX_PATH] = {};
-    LPWSTR szFileName = NULL;
     HANDLE hProcess = GetCurrentProcess();
     WIN32_FIND_DATAW FindFileData = {};
-    THREADENTRY32 te = {.dwSize = sizeof(THREADENTRY32)};
-    MODULEENTRY32W me = {.dwSize = sizeof(MODULEENTRY32W)};
-    HANDLE hThreadSnapshot = 0, hModuleSnapshot = 0, hThread = 0;
-    DWORD64 dw64StartAddress = 0;
-    PWTS_PROCESS_INFOW pProcessInfo = 0;
-    DWORD dwCount = 0;
-    BOOL bSuspended = FALSE;
+    PWTS_PROCESS_INFOW pProcessInfo = NULL;
+    DWORD Count = 0;
 
     QueryFullProcessImageNameW(hProcess, 0, lpPathName, &((DWORD){MAX_PATH}));
     for (DWORD dwIndex = MAX_PATH; dwIndex < -1; dwIndex -= 1)
@@ -35,7 +94,12 @@ INT WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nC
         }
     }
 
-    HANDLE hFindFile = FindFirstFileW(lpPathName, &FindFileData);
+    HANDLE hFindFile = FindFirstFileExW(lpPathName,
+                                        FindExInfoBasic,
+                                        &FindFileData,
+                                        FindExSearchLimitToDirectories,
+                                        NULL,
+                                        FIND_FIRST_EX_LARGE_FETCH);
     if (hFindFile)
     {
         do
@@ -47,46 +111,22 @@ INT WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR pCmdLine, int nC
                         if (PathFileExistsW(lpProcesses[iIndex]))
                         {
                             szFileName = lpProcesses[iIndex];
+                            EnumWindows(EnumWindowsProc, 0);
+                            ShellExecuteW(NULL, NULL, szFileName, NULL, NULL, SW_SHOWNORMAL);
+                            SetWinEventHook(EVENT_OBJECT_CREATE,
+                                            EVENT_OBJECT_CREATE,
+                                            NULL,
+                                            WinEventProc,
+                                            0,
+                                            0,
+                                            WINEVENT_OUTOFCONTEXT);
+                            while (GetMessageW(&((MSG){}), NULL, 0, 0))
+                                ;
                             break;
                         }
         while (FindNextFileW(hFindFile, &FindFileData));
         FindClose(hFindFile);
     }
 
-    if (szFileName)
-    {
-        ShellExecuteW(NULL, NULL, szFileName, NULL, NULL, SW_SHOWNORMAL);
-        while (!bSuspended && !SleepEx(1, TRUE))
-        {
-            WTSEnumerateProcessesW(WTS_CURRENT_SERVER, 0, 1, &pProcessInfo, &dwCount);
-            for (DWORD dwIndex = 0; dwIndex < dwCount; dwIndex++)
-            {
-                if (wcscmp(szFileName, _wcslwr(pProcessInfo[dwIndex].pProcessName)))
-                    continue;
-                if (Thread32First((hThreadSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPTHREAD, 0)), &te))
-                {
-                    do
-                    {
-                        if (te.th32OwnerProcessID != pProcessInfo[dwIndex].ProcessId)
-                            continue;
-                        hThread = OpenThread(THREAD_ALL_ACCESS, FALSE, te.th32ThreadID);
-                        NtQueryInformationThread(hThread, ThreadQuerySetWin32StartAddress, &dw64StartAddress, sizeof(DWORD64), NULL);
-                        if (Module32FirstW((hModuleSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPMODULE32 | TH32CS_SNAPMODULE, pProcessInfo[dwIndex].ProcessId)), &me))
-                            do
-                            {
-                                if (dw64StartAddress >= (DWORD64)me.modBaseAddr &&
-                                    dw64StartAddress <= ((DWORD64)me.modBaseAddr + me.modBaseSize) &&
-                                    !wcscmp(me.szModule, L"discord_utils.node"))
-                                    bSuspended = SuspendThread(hThread);
-                            } while (Module32NextW(hModuleSnapshot, &me));
-                        CloseHandle(hModuleSnapshot);
-                        CloseHandle(hThread);
-                    } while (Thread32Next(hThreadSnapshot, &te));
-                }
-                CloseHandle(hThreadSnapshot);
-            }
-            WTSFreeMemory(pProcessInfo);
-        }
-    }
     return 0;
 }


### PR DESCRIPTION
1. Using WinEvent Hooks, its possible to find what process is hosting the `discord_utils.node` module.
2. File enumeration is used to find a Discord executable.